### PR TITLE
rework save_email_copy to allow multiple recipients...

### DIFF
--- a/classes/class-cpt-wplf-form.php
+++ b/classes/class-cpt-wplf-form.php
@@ -384,7 +384,25 @@ class CPT_WPLF_Form {
 
     // save email copy
     if ( isset( $_POST['wplf_email_copy_to'] ) ) {
-      update_post_meta( $post_id, '_wplf_email_copy_to', sanitize_email( $_POST['wplf_email_copy_to'] ) );
+      $emailField = $_POST['wplf_email_copy_to'];
+      $to = '';
+
+      if( strpos( $emailField, "," ) > 0 ) {
+        // Intentional. Makes no sense if the first character is a comma, so pass it along as a single address.
+        // sanitize_email() should take care of the rest.
+        $emailArray = explode( ",", $emailField );
+        foreach($emailArray as $email){
+          $email = trim($email);
+          $email = sanitize_email( trim( $email ) ) . ", ";
+          $to .= $email;
+        }
+        $to = rtrim( $to, ", " );
+      }
+      else {
+        $to = sanitize_email( $emailField );
+      }
+
+      update_post_meta( $post_id, '_wplf_email_copy_to', $to );
     }
 
     // save title format

--- a/classes/class-cpt-wplf-form.php
+++ b/classes/class-cpt-wplf-form.php
@@ -393,7 +393,7 @@ class CPT_WPLF_Form {
         $emailArray = explode( ",", $emailField );
         foreach($emailArray as $email){
           $email = trim($email);
-          $email = sanitize_email( trim( $email ) ) . ", ";
+          $email = sanitize_email( $email ) . ", ";
           $to .= $email;
         }
         $to = rtrim( $to, ", " );


### PR DESCRIPTION
…in comma separated form. 

So you can supply a comma separated list of recipients to the "email copy" field in the form to the $to parameter in [wp_mail()](https://developer.wordpress.org/reference/functions/wp_mail/).

Tested with `some@address.com`, `,some@address.com`, `some@address.com,some2@address.com` & `some@address.com, some2@address.com`. 

Might be worth mentioning this is my first cherry-picked commit ever, so if there's any problems, blame it on that. But the diff looks fine :) 