### PR TITLE
Remove _wplf_email_copy_to meta if input is empty

### DIFF
--- a/classes/class-cpt-wplf-form.php
+++ b/classes/class-cpt-wplf-form.php
@@ -332,7 +332,7 @@ class CPT_WPLF_Form {
 ?>
 <p><?php _e('Submissions from this form will use this formatting in their title.', 'wp-libre-form'); ?></p>
 <p><?php _e('You may use any field values enclosed in "%" markers.', 'wp-libre-form');?></p>
-<p><input type="text" name="wplf_title_format" value="<?php echo esc_attr( $format ); ?>" placeholder="<?php echo esc_attr( $default ); ?>" class="code" style="width:100%"></p>
+<p><input type="text" name="wplf_title_format" value="<?php echo esc_attr( $format ); ?>" placeholder="<?php echo esc_attr( $default ); ?>" class="code" style="width:100%" autocomplete="off"></p>
 <?php
   }
 

--- a/classes/class-cpt-wplf-form.php
+++ b/classes/class-cpt-wplf-form.php
@@ -402,7 +402,11 @@ class CPT_WPLF_Form {
         $to = sanitize_email( $emailField );
       }
 
-      update_post_meta( $post_id, '_wplf_email_copy_to', $to );
+      if( !empty( $to ) ) {
+        update_post_meta( $post_id, '_wplf_email_copy_to', $to );
+      } else {
+        delete_post_meta( $post_id, '_wplf_email_copy_to' );
+      }
     }
 
     // save title format


### PR DESCRIPTION
Fixes #25.

I did also set autocomplete off in `wplf_title_format` input, because filling `wplf_email_copy_to` with autocomplete did change it's value also. This caused wrongly submission titles.