### PR TITLE
Change WPLF_Polylang regex to be less greedy.

### DIFF
--- a/classes/class-wplf-polylang.php
+++ b/classes/class-wplf-polylang.php
@@ -5,7 +5,7 @@ if ( !class_exists( 'WPLF_Polylang' ) ) {
      * CPT for the forms
      */
     public static $instance;
-    protected $regular_expression = "/{{\s*.+\s*}}/";
+    protected $regular_expression = "/{{[^{}\n]+}}/";
     protected $strings = array();
 
     public static function init() {


### PR DESCRIPTION
This allows double delimiters in case something else uses the {{varname}} syntax as discussed in #33