### PR TITLE
bump version to 1.2.1 because w.org repo fix

### DIFF
--- a/wp-libre-form.php
+++ b/wp-libre-form.php
@@ -3,7 +3,7 @@
  * Plugin name: WP Libre Form
  * Plugin URI: https://github.com/anttiviljami/wp-libre-form
  * Description: A minimal HTML form builder for WordPress; made for developers
- * Version: 1.2
+ * Version: 1.2.1
  * Author: @anttiviljami
  * Author URI: https://github.com/anttiviljami/
  * License: GPLv3
@@ -31,7 +31,7 @@
 
 if ( ! class_exists( 'WP_Libre_Form' ) ) :
 
-define( 'WPLF_VERSION', '1.2' );
+define( 'WPLF_VERSION', '1.2.1' );
 
 class WP_Libre_Form {
   public static $instance;


### PR DESCRIPTION
wordpress.org svn repository lacks class-wplf-polylang.php file and it's required by default. If plugin is installed via w.org repo, it breaks your site and and causes 500 because of this.

We need to add class-wplf-polylang.php to w.org repo and bump the version to w.org notice the change. Git repo needs version bump also due to the consistency.