### PR TITLE
Support for email templates and a big set of other changes

### DIFF
--- a/assets/scripts/wplf-admin-form.js
+++ b/assets/scripts/wplf-admin-form.js
@@ -57,9 +57,9 @@ $(document).ready(function() {
   // display email copy field if the feature is enabled
   function toggleEmailCopy() {
     if( $('input[name="wplf_email_copy_enabled"]:checked').length > 0 ) {
-      $('input[name="wplf_email_copy_to"]').show();
+      $('.wplf-email-fields').show();
     } else {
-      $('input[name="wplf_email_copy_to"]').hide();
+      $('.wplf-email-fields').hide();
     }
   }
   $('input[name="wplf_email_copy_enabled"]').change(toggleEmailCopy);

--- a/classes/class-cpt-wplf-form.php
+++ b/classes/class-cpt-wplf-form.php
@@ -436,14 +436,7 @@ class CPT_WPLF_Form {
 
     // save title format
     if ( isset( $_POST['wplf_title_format'] ) ) {
-      $safe_title_format = $_POST['wplf_title_format']; // TODO: are there any applicable sanitize functions?
-
-      // A typical title format will include characters like <, >, %, -.
-      // which means all sanitize_* fuctions will probably mess with the field
-      // The only place the title formats are displayed are within value=""
-      // attributes where of course they are escaped using esc_attr() so it
-      // should be fine to save the meta field without further sanitisaton
-      update_post_meta( $post_id, '_wplf_title_format', $safe_title_format );
+      update_post_meta( $post_id, '_wplf_title_format', $_POST['wplf_title_format'] );
     }
   }
 

--- a/classes/class-cpt-wplf-form.php
+++ b/classes/class-cpt-wplf-form.php
@@ -344,7 +344,38 @@ class CPT_WPLF_Form {
   </label>
 </p>
 <div class="wplf-email-fields" style="display: none">
-<p><input type="text" name="wplf_email_copy_to" value="<?php echo esc_attr( $email_copy_to ); ?>" placeholder="<?php echo esc_attr( get_option( 'admin_email' ) ); ?>" style="width:100%;display:none"></p>
+<p><strong><?php _e('Email Recipient') ?></strong></p>
+<p><input type="text" name="wplf_email_copy_to" value="<?php echo esc_attr( $email_copy_to ); ?>" placeholder="<?php echo esc_attr( get_option( 'admin_email' ) ); ?>" style="width:100%"></p>
+
+<?php
+  $wplf = WP_Libre_Form::init();
+  $templates = $wplf->get_email_templates();
+
+?>
+<p><strong><?php _e('Email Template') ?></strong></p>
+<p><select name="wplf_email_copy_template" id="wplf_email_copy_template" style="width: 100%">
+
+<?php
+    $default = isset( $meta['_wplf_email_copy_template'] ) ? $meta['_wplf_email_copy_template'][0] : '';
+    ksort( $templates );
+    foreach ( $templates as $key => $template ) {
+        $selected = selected( $default, $key, false );
+        $templateName = $template['name'];
+        echo "\n\t<option value='" . $key . "' $selected>$templateName</option>";
+    }
+
+?>
+
+</select></p>
+
+<?php
+$default = apply_filters( 'wplf_default_email_copy_subject', __( '%title% - New submission from %name%', 'wp-libre-form' ), 'meta-box');
+$format = isset( $meta['_wplf_email_copy_subject_format'] ) ? $meta['_wplf_email_copy_subject_format'][0] : $default;
+?>
+<p><strong><?php _e('Subject Template') ?></strong></p>
+<p><?php _e('Submissions from this form will use this formatting in their email subject.', 'wp-libre-form'); ?></p>
+<p><?php _e('You may use any field values enclosed in "%" markers.', 'wp-libre-form');?></p>
+<p><input type="text" name="wplf_email_copy_subject_format" value="<?php echo esc_attr( $format ); ?>" placeholder="<?php echo esc_attr( $default ); ?>" class="code" style="width:100%" autocomplete="off"></p>
 </div>
 
 <?php
@@ -408,6 +439,16 @@ class CPT_WPLF_Form {
     }
     else {
       update_post_meta( $post_id, '_wplf_email_copy_enabled', false );
+    }
+
+    // email template
+    if ( isset( $_POST['wplf_email_copy_template'] ) ) {
+      update_post_meta( $post_id, '_wplf_email_copy_template', $_POST['wplf_email_copy_template'] );
+    }
+
+    // email subject format
+    if ( isset( $_POST['wplf_email_copy_subject_format'] ) ) {
+      update_post_meta( $post_id, '_wplf_email_copy_subject_format', $_POST['wplf_email_copy_subject_format'] );
     }
 
     // save email copy

--- a/classes/class-cpt-wplf-form.php
+++ b/classes/class-cpt-wplf-form.php
@@ -343,7 +343,10 @@ class CPT_WPLF_Form {
     <?php _e( 'Send an email copy when a form is submitted?', 'wp-libre-form' ); ?>
   </label>
 </p>
+<div class="wplf-email-fields" style="display: none">
 <p><input type="text" name="wplf_email_copy_to" value="<?php echo esc_attr( $email_copy_to ); ?>" placeholder="<?php echo esc_attr( get_option( 'admin_email' ) ); ?>" style="width:100%;display:none"></p>
+</div>
+
 <?php
   }
 

--- a/email-templates/default.php
+++ b/email-templates/default.php
@@ -1,0 +1,15 @@
+<?php
+/**
+WPLF Template Name: Default
+
+*/
+
+
+echo wp_sprintf( __('Form "%s" (ID %d) was submitted with values below:' . "\n", 'wp-libre-form'), $form->post_title, $form->ID);
+
+foreach( $data as $key => $value ) {
+  if( '_' === $key[0] ) {
+    continue;
+  }
+  echo $key . ': ' . print_r( $value, true ) . "\r\n";
+}

--- a/inc/wplf-ajax.php
+++ b/inc/wplf-ajax.php
@@ -6,6 +6,7 @@
 add_action( 'wp_ajax_wplf_submit', 'wplf_ajax_submit_handler' );
 add_action( 'wp_ajax_nopriv_wplf_submit', 'wplf_ajax_submit_handler' );
 function wplf_ajax_submit_handler() {
+  $wplf = WP_Libre_Form::init();
   $return = new stdClass();
   $return->ok = 1;
 
@@ -17,34 +18,58 @@ function wplf_ajax_submit_handler() {
   $return = apply_filters( 'wplf_validate_submission', $return );
 
   if( $return->ok ) {
+    // copy $_POST to $data in order to undo WordPress' magic quotes for
+    // wplf_post_data. Filtered data will be escaped appropriately.
+    $data = stripslashes_deep($_POST);
+
     // form existence has already been validated via filters
+    $form = get_post( intval( $data['_form_id'] ) );
 
-    // copy $_POST to $form_data in order to undo WordPress' magic quotes
-    $form_data = stripslashes_deep($_POST);
 
-    // Make form data filterable
-    $form_data = apply_filters( 'wplf_form_data', $form_data );
+    // Make POST data filterable
+    $data = apply_filters( 'wplf_submission_data', $data );
 
-    $form = get_post( intval( $form_data['_form_id'] ) );
+    $form_meta = get_post_meta( $form->ID );
 
-    $title_format = get_post_meta( $form->ID, '_wplf_title_format', true );
+    // Compile all relevant data into a single array. This will be passed to wplf_post_validate_submission,
+    // so the same data wouldn't have to be looked up again.
+    // This is mostly for aesthetic reasons and DRY KISS.
+    $submission = [
+      'data' => $data,      // Filtered POST data
+      'meta' => [],         // Form metadata
+      'form' => $form,      // Form object
+      'post_title' => '',   // Filtered submission title
+    ];
+    // Seems that all metadata have only 1 value, so we simplify the structure a bit.
+    // TODO: Just to be sure, here's a reminder to check
+    foreach ($form_meta as $key => $value) {
+      $submission['meta'][$key] = $value[0];
+    }
 
-    // substitute the %..% tags with field values
-    $post_title = $title_format;
+    // Try _wplf_title_format from metadata but if it for some reason fails, just use form name
+    $title_format = !empty($submission['meta']['_wplf_title_format']) ? $submission['meta']['_wplf_title_format'] : $form->post_title;
+    $title_format = apply_filters('wplf_submission_title_format', $title_format);
 
-    $wplf = WP_Libre_Form::init();
-    $post_title = $wplf->substitute($post_title, $form_data);
+
+    // special values for subtitution that need an easier key are not really usable elsewhere
+    $specialValues = [
+      'form-name' => $form->post_title,
+    ];
+      // Assign submission title and substitute tokens
+    $submission['post_title'] = $wplf->substitute($title_format, $specialValues, false);
+    $submission['post_title'] = $wplf->substitute($submission['post_title'], $submission['data']);
+    // Probably no extra value in filtering post title, since $title_format has a filter already, so skip it.
 
     // create submission post
     $post_id = wp_insert_post( array(
-      'post_title'     => $post_title,
+      'post_title'     => $submission['post_title'],
       'post_status'    => 'publish',
       'post_type'      => 'wplf-submission',
     ));
 
     // add submission data as meta values
-    foreach( $form_data as $key => $value ) {
-      if ( $slash = is_array($value ) )
+    foreach( $submission['data'] as $key => $value ) {
+      if ( is_array($value ) )
         $value = json_encode($value);
 
       // Escape slashes for add_post_meta (https://codex.wordpress.org/Function_Reference/update_post_meta#Character_Escaping)
@@ -60,20 +85,25 @@ function wplf_ajax_submit_handler() {
       $attach_id = media_handle_upload( $key, 0, array(), array( "test_form" => false ) );
       add_post_meta( $post_id, $key, wp_get_attachment_url($attach_id) );
       add_post_meta( $post_id, $key . "_attachment", $attach_id );
+
+      // TODO: For completeness' sake attachments should also be added to submission
     }
 
 
 
     $return->submission_id = $post_id;
-    $return->submission_title = $post_title;
+    $return->submission_title = $submission['post_title'];
     $return->form_id = $form->ID;
 
     // return the success message for the form
-    $return->success = apply_filters( 'the_content', get_post_meta( $form->ID, '_wplf_thank_you', true ) );
+    $return->success = apply_filters( 'the_content', $submission['meta']['_wplf_thank_you'], true );
+
+    if (WP_DEBUG)
+      $return->debug = $submission;
 
     // allow user to attach custom actions after the submission has been received
     // these could be confirmation emails, additional processing for the submission fields, e.g.
-    do_action('wplf_post_validate_submission', $return);
+    do_action('wplf_post_validate_submission', $return, $submission);
 
   }
 

--- a/inc/wplf-ajax.php
+++ b/inc/wplf-ajax.php
@@ -33,14 +33,8 @@ function wplf_ajax_submit_handler() {
     // substitute the %..% tags with field values
     $post_title = $title_format;
 
-    preg_match_all('/%(.+?)%/', $post_title, $toks);
-    foreach($toks[1] as $tok) {
-      $replace = '';
-      if( array_key_exists( $tok, $form_data ) ) {
-        $replace = sanitize_text_field( $form_data[$tok] );
-      }
-      $post_title = preg_replace('/%.+?%/', $replace, $post_title, 1);
-    }
+    $wplf = WP_Libre_Form::init();
+    $post_title = $wplf->substitute($post_title, $form_data);
 
     // create submission post
     $post_id = wp_insert_post( array(

--- a/inc/wplf-ajax.php
+++ b/inc/wplf-ajax.php
@@ -27,7 +27,6 @@ function wplf_ajax_submit_handler() {
 
     $form = get_post( intval( $form_data['_form_id'] ) );
 
-    // the title is the value of whatever the first field was in the form
     $title_format = get_post_meta( $form->ID, '_wplf_title_format', true );
 
     // substitute the %..% tags with field values

--- a/inc/wplf-form-actions.php
+++ b/inc/wplf-form-actions.php
@@ -3,40 +3,88 @@
 /**
  * Send a copy of the form fields email if feature is enabled
  */
-add_action( 'wplf_post_validate_submission', 'wplf_send_email_copy', 20 );
-function wplf_send_email_copy( $return ) {
+add_action( 'wplf_post_validate_submission', 'wplf_send_email_copy', 20, 2 );
+function wplf_send_email_copy( $return, $submission ) {
+  $wplf = WP_Libre_Form::init();
   // do nothing if form validation failed
-  if( ! $return->ok ) {
+  if( ! $return->ok )
     return;
+
+
+  // do nothing if email is disabled
+  if( !isset( $submission['meta']['_wplf_email_copy_enabled'] ) || !$submission['meta']['_wplf_email_copy_enabled'][0] )
+    return;
+
+  $submission['email'] = [
+    'headers' => [],
+    'charset' => 'UTF-8',
+    'mime' => ''
+  ];
+  // Email specific filtering here
+
+  $subject_format = isset( $submission['meta']['_wplf_email_copy_subject_format'] )
+    ? $submission['meta']['_wplf_email_copy_subject_format']
+    : '%title% - New submission from %name%';
+
+  $subject_format = apply_filters( 'wplf_email_copy_subject_format', $subject_format );
+
+  // special values for subtitution that need an easier key are not really usable elsewhere
+  $special_values = [
+    'form-name' => $submission['form']->post_title,
+  ];
+    // Assign submission title and substitute tokens
+  $submission['email']['subject'] = $wplf->substitute($subject_format, $special_values, false);
+  $submission['email']['subject'] = $wplf->substitute($submission['email']['subject'] , $submission['data'] );
+
+  // Locate and render template
+
+  $template_file = !empty( $submission['meta']['_wplf_email_copy_template'] ) ? $submission['meta']['_wplf_email_copy_template'] : '';
+  // Don't use locate_template(). This is easier.
+  $templates = $wplf->get_email_templates();
+
+  // If chosen template can't for some reason be found, use default.
+  if ( !isset( $templates[$template_file] ) )
+    $template_file = '_wplf/default.php';
+
+  $template = $templates[$template_file];
+
+  // Extract submission data to local scope for the template
+  extract( $submission );
+  ob_start();
+  require( $template['path'] );
+  $content = ob_get_clean();
+
+
+  if (!$submission['email']['mime']) {
+    // Try a filter to detect html content
+    $is_html = apply_filters( 'wplf_email_copy_detect_html', null, $content, $submission);
+
+    // If $is_html is still null(no filters / no html detected), try to match /<html.*>/
+    if ($is_html === null)
+      $is_html = preg_match('/<html(\s+.*)?>/', $content); // Content is probably a html document
+
+    if ($is_html !== null)
+      $submission['email']['mime'] = $is_html ? 'text/html' : 'text/plain';
+  }
+  $submission['email']['headers']['Content-Type'] = $submission['email']['mime'] . ';charset=' . $submission['email']['charset'];
+
+  // Normalize headers
+  foreach ($submission['email']['headers'] as $key => $value) {
+    if (!is_int($key))
+      $value = $key . ': ' . $value;
+
+    $submission['email']['headers'] = $value;
   }
 
-  $form_id = intval( $_POST['_form_id'] ); // _form_id is already validated and we know it exists by this point
-  $form_title = esc_html( get_the_title( $form_id ) );
-  $form_meta = get_post_meta( $form_id );
-  $referrer = esc_url_raw( $_POST['referrer'] );
+  // Last chance to filter $submission
+  $submission = apply_filters( 'wplf_email_submission_send', $submission);
 
-  if( isset($form_meta['_wplf_email_copy_enabled']) && $form_meta['_wplf_email_copy_enabled'][0] ) {
-    $to = isset($form_meta['_wplf_email_copy_to']) ? $form_meta['_wplf_email_copy_to'][0] : get_option( 'admin_email' );
-    $subject = wp_sprintf( __('New submission from %s', 'wp-libre-form'), $referrer );
-    $content = wp_sprintf( __('Form "%s" (ID %d) was submitted with values below: ', 'wp-libre-form'), $form_title, $form_id );
-    $content = apply_filters( 'wplf_email_copy_content_start', $content, $form_title, $form_id ). "\n\n";
+  wp_mail(
+    apply_filters( 'wplf_email_copy_to', $submission['meta']['_wplf_email_copy_to'], $submission ),
+    apply_filters( 'wplf_email_copy_subject', $submission['email']['subject'], $submission ),
+    apply_filters( 'wplf_email_copy_content', $content, $submission ),
+    apply_filters( 'wplf_email_copy_headers', $submission['email']['headers'], $submission ),
+    apply_filters( 'wplf_email_copy_attachments', array(), $submission )
+  );
 
-    foreach( $_POST as $key => $value ) {
-      if( '_' === $key[0] ) {
-        continue;
-      }
-      if( is_array( $value ) ) { // in case input type="radio" submits an array
-        $value = implode( ', ', $value );
-      }
-      $content .= esc_html( $key ) . ': ' . esc_html( print_r( $value, true ) ) . "\n";
-    }
-
-    wp_mail(
-      apply_filters( 'wplf_email_copy_to', $to ),
-      apply_filters( 'wplf_email_copy_subject', $subject ),
-      apply_filters( 'wplf_email_copy_content', $content ),
-      apply_filters( 'wplf_email_copy_headers', '' ),
-      apply_filters( 'wplf_email_copy_attachments', array() )
-    );
-  }
 }

--- a/wp-libre-form.php
+++ b/wp-libre-form.php
@@ -96,6 +96,33 @@ class WP_Libre_Form {
   public function wplf_form( $id, $content = '', $xclass = '' ) {
     return CPT_WPLF_Form::wplf_form( $id, $content, $xclass );
   }
+
+  /**
+  * Substitutes %..% tokens in $string with values with corresponding keys in $data.
+  *
+  * @param string $string     Input string
+  * @param array  $data       Key-value pairs to substitute in $string
+  * @param bool   $cleanup    Remove unused tokens at the end
+  */
+public function substitute($string, $data = array(), $cleanup = true) {
+    // Moved and modified from wplf-ajax.php
+
+    preg_match_all('/%(.+?)%/', $string, $toks);
+    $toks = array_unique($toks);
+    foreach($toks[1] as $tok) {
+      $replace = '';
+      if( array_key_exists( $tok, $data ) ) {
+        $replace = sanitize_text_field( $data[$tok] );
+        $string = str_replace('%' . $tok . '%', $replace, $string);
+      }
+    }
+
+    // cleanup
+    if ($cleanup)
+      $string = preg_replace('/%.+?%/', '', $string);
+
+    return $string;
+  }
 }
 
 endif;

--- a/wp-libre-form.php
+++ b/wp-libre-form.php
@@ -108,8 +108,8 @@ public function substitute($string, $data = array(), $cleanup = true) {
     // Moved and modified from wplf-ajax.php
 
     preg_match_all('/%(.+?)%/', $string, $toks);
-    $toks = array_unique($toks);
-    foreach($toks[1] as $tok) {
+    $toks = array_unique($toks[1]);
+    foreach($toks as $tok) {
       $replace = '';
       if( array_key_exists( $tok, $data ) ) {
         $replace = sanitize_text_field( $data[$tok] );


### PR DESCRIPTION
This is based on #40 but a lot has changed

* Data is mostly handled in wplf-ajax and passed forward as a single array
* Added various filters
* HTML content is detected automatically and headers are set accordingly

Some features need to be documented and this hasn't been completely tested. That said, playing with a few different templates and settings didn't seem to break anything, so this is going to production on my site for now.

Templates work automatically from the plugin's email-templates directory and theme's(+child theme) directory. Themes are searched 1 directory level deep and are identified with the same header format you'd use in page templates. See wp-libre-form/email-templates/default.php.

This is more like a proof of concept and I don't expect it to be pulled as-is. Maybe after I've double-checked everything I hope there's at least some code you can use. Let me know if you find anything that needs to be fixed or changed, and like I said earlier, we can have a chat in finnish to clear things up faster.