### PR TITLE
Send cookies (credentials) by default

### DIFF
--- a/assets/scripts/wplf-form.js
+++ b/assets/scripts/wplf-form.js
@@ -26,7 +26,8 @@
 
       fetch(ajax_object.ajax_url  + '?action=wplf_submit', {
         method: "POST",
-        body: data
+        body: data,
+        credentials: 'same-origin'
       }).then(function(response) {
         return response.text();
       }).then(function(response) {


### PR DESCRIPTION
As discussed in #53, currently no cookies are sent with the request. 
This causes problems with Seravo staging instances.  

This also makes the script behave like XHR does by default.