### PR TITLE
Add multilingual support for success messages

### DIFF
--- a/assets/scripts/wplf-form.js
+++ b/assets/scripts/wplf-form.js
@@ -15,6 +15,10 @@
     submitHandler: function (e) {
       var form = e.target;
       var data = new FormData(form);
+
+      // Pass language if it exists.
+      ajax_object.lang && data.append('lang', ajax_object.lang);
+
       // add class to enable css changes to indicate ajax loading
       form.classList.add("sending");
 

--- a/classes/class-cpt-wplf-form.php
+++ b/classes/class-cpt-wplf-form.php
@@ -18,7 +18,7 @@ class CPT_WPLF_Form {
   /**
    * Hook our actions, filters and such
    */
-  private function __construct() {
+  public function __construct() {
     // init custom post type
     add_action( 'init', array( $this, 'register_cpt' ) );
 
@@ -385,7 +385,7 @@ class CPT_WPLF_Form {
     $format = isset( $meta['_wplf_title_format'] ) ? $meta['_wplf_title_format'][0] : $default;
 ?>
 <p><?php esc_html_e( 'Submissions from this form will use this formatting in their title.', 'wp-libre-form' ); ?></p>
-<p><?php esc_html_e( 'You may use any field values enclosed in "%" markers.', 'wp-libre-form' );?></p>
+<p><?php esc_html_e( 'You may use any field values enclosed in "%" markers.', 'wp-libre-form' ); ?></p>
 <p>
   <input
     type="text"
@@ -542,10 +542,10 @@ class CPT_WPLF_Form {
     ?>
       <p style="background:#f5f5f5;border-left:4px solid #dc3232;padding:6px 12px;">
         <strong style="color:#dc3232;">
-          <?php esc_html_e( 'This form preview URL is not public and cannot be shared.', 'wp-libre-form' ) ?>
+          <?php esc_html_e( 'This form preview URL is not public and cannot be shared.', 'wp-libre-form' ); ?>
         </strong>
         <br />
-        <?php esc_html_e( 'Non-logged in visitors will see a 404 error page instead.', 'wp-libre-form' ) ?>
+        <?php esc_html_e( 'Non-logged in visitors will see a 404 error page instead.', 'wp-libre-form' ); ?>
       </p>
     <?php endif; ?>
   <?php endif; ?>
@@ -556,7 +556,7 @@ class CPT_WPLF_Form {
     // @codingStandardsIgnoreEnd
   ?>
   <input type="hidden" name="referrer" value="<?php the_permalink(); ?>">
-  <input type="hidden" name="_referrer_id" value="<?php echo esc_attr( get_the_id() ) ?>">
+  <input type="hidden" name="_referrer_id" value="<?php echo esc_attr( get_the_id() ); ?>">
   <input type="hidden" name="_form_id" value="<?php echo esc_attr( $id ); ?>">
 </form>
 <?php

--- a/classes/class-cpt-wplf-form.php
+++ b/classes/class-cpt-wplf-form.php
@@ -423,7 +423,9 @@ class CPT_WPLF_Form {
 
     // save success message
     if ( isset( $_POST['wplf_thank_you'] ) ) {
-      update_post_meta( $post_id, '_wplf_thank_you', wp_kses_post( $_POST['wplf_thank_you'] ) );
+      $success = wp_kses_post( $_POST['wplf_thank_you'] );
+      $success = apply_filters( 'wplf_save_success_message', $success, $post_id );
+      update_post_meta( $post_id, '_wplf_thank_you', $success );
     }
 
     // save fields

--- a/classes/class-cpt-wplf-form.php
+++ b/classes/class-cpt-wplf-form.php
@@ -589,10 +589,10 @@ class CPT_WPLF_Form {
     );
 
     // add dynamic variables to the script's scope
-    wp_localize_script( 'wplf-form-js', 'ajax_object', array(
+    wp_localize_script( 'wplf-form-js', 'ajax_object', apply_filters( 'wplf_ajax_object', array(
       'ajax_url' => admin_url( 'admin-ajax.php' ),
       'ajax_credentials' => apply_filters( 'wplf_ajax_fetch_credentials_mode', 'same-origin' ),
-    ) );
+    ) ) );
   }
 
 

--- a/classes/class-cpt-wplf-submission.php
+++ b/classes/class-cpt-wplf-submission.php
@@ -18,7 +18,7 @@ class CPT_WPLF_Submission {
   /**
    * Hook our actions, filters and such
    */
-  private function __construct() {
+  public function __construct() {
     // init custom post type
     add_action( 'init', array( $this, 'register_cpt' ) );
 

--- a/classes/class-wplf-polylang.php
+++ b/classes/class-wplf-polylang.php
@@ -24,6 +24,7 @@ if ( ! class_exists( 'WPLF_Polylang' ) ) {
       // Earlier than default. User probably wants to filter the translated message.
       add_action( 'wplf_success_message', array( $this, 'render_success_message' ), 9 );
       add_action( 'wplf_save_success_message', array( $this, 'save_success_message' ) );
+      add_action( 'wplf_ajax_object', array( $this, 'ajax_object' ) );
 
       $this->strings = get_option( 'wplf-translation-strings', array() );
       $this->register_strings();
@@ -83,6 +84,11 @@ if ( ! class_exists( 'WPLF_Polylang' ) ) {
       update_option( 'wplf-translation-strings', $this->strings ); // Let's be optimistic.
 
       return $message;
+    }
+
+    public function ajax_object($array) {
+      $array['lang'] = pll_current_language();
+      return $array;
     }
 
     public function register_strings() {

--- a/classes/class-wplf-polylang.php
+++ b/classes/class-wplf-polylang.php
@@ -21,6 +21,10 @@ if ( ! class_exists( 'WPLF_Polylang' ) ) {
       add_filter( 'save_post_wplf-form', array( $this, 'save_form' ), 10, 3 );
       add_action( 'after_setup_theme', array( $this, 'register_strings' ) );
 
+      // Earlier than default. User probably wants to filter the translated message.
+      add_action( 'wplf_success_message', array( $this, 'render_success_message' ), 9 );
+      add_action( 'wplf_save_success_message', array( $this, 'save_success_message' ) );
+
       $this->strings = get_option( 'wplf-translation-strings', array() );
       $this->register_strings();
     }
@@ -51,6 +55,34 @@ if ( ! class_exists( 'WPLF_Polylang' ) ) {
       }
 
       update_option( 'wplf-translation-strings', $this->strings ); // Let's be optimistic.
+    }
+
+    public function render_success_message($message) {
+      // Get all strings inside double curly braces.
+      preg_match_all( $this->regular_expression, $message, $matches );
+      foreach ( $matches[0] as $match ) {
+        // match contains the braces, get rid of them.
+        $string = trim( str_replace( array( '{', '}' ), array( '', '' ), $match ) );
+        $message = str_replace( $match, $this->translate_string( $string ), $message );
+      }
+
+      return $message;
+    }
+
+    public function save_success_message($message) {
+      preg_match_all( $this->regular_expression, $message, $matches );
+      if ( ! empty( $matches ) ) {
+        foreach ( $matches[0] as $match ) {
+          // match contains the braces, get rid of them.
+          $string = trim( str_replace( array( '{', '}' ), array( '', '' ), $match ) );
+          $this->strings[ $string ] = null;
+          // By storing the string as the array key, we don't need to use array_unique.
+        }
+      }
+
+      update_option( 'wplf-translation-strings', $this->strings ); // Let's be optimistic.
+
+      return $message;
     }
 
     public function register_strings() {

--- a/classes/class-wplf-polylang.php
+++ b/classes/class-wplf-polylang.php
@@ -58,7 +58,7 @@ if ( ! class_exists( 'WPLF_Polylang' ) ) {
       update_option( 'wplf-translation-strings', $this->strings ); // Let's be optimistic.
     }
 
-    public function render_success_message($message) {
+    public function render_success_message( $message ) {
       // Get all strings inside double curly braces.
       preg_match_all( $this->regular_expression, $message, $matches );
       foreach ( $matches[0] as $match ) {
@@ -70,7 +70,7 @@ if ( ! class_exists( 'WPLF_Polylang' ) ) {
       return $message;
     }
 
-    public function save_success_message($message) {
+    public function save_success_message( $message ) {
       preg_match_all( $this->regular_expression, $message, $matches );
       if ( ! empty( $matches ) ) {
         foreach ( $matches[0] as $match ) {
@@ -86,7 +86,7 @@ if ( ! class_exists( 'WPLF_Polylang' ) ) {
       return $message;
     }
 
-    public function ajax_object($array) {
+    public function ajax_object( $array ) {
       $array['lang'] = pll_current_language();
       return $array;
     }

--- a/classes/class-wplf-polylang.php
+++ b/classes/class-wplf-polylang.php
@@ -16,7 +16,7 @@ if ( ! class_exists( 'WPLF_Polylang' ) ) {
     /**
      * Hook our actions, filters and such
      */
-    private function __construct() {
+    public function __construct() {
       add_filter( 'wplf_form', array( $this, 'render_form' ) );
       add_filter( 'save_post_wplf-form', array( $this, 'save_form' ), 10, 3 );
       add_action( 'after_setup_theme', array( $this, 'register_strings' ) );

--- a/classes/class-wplf-polylang.php
+++ b/classes/class-wplf-polylang.php
@@ -1,9 +1,7 @@
 <?php
 if ( ! class_exists( 'WPLF_Polylang' ) ) {
   class WPLF_Polylang {
-    /**
-     * CPT for the forms
-     */
+
     public static $instance;
     protected $regular_expression = "/{{[^{}\n]+}}/";
     protected $strings = array();

--- a/inc/wplf-ajax.php
+++ b/inc/wplf-ajax.php
@@ -81,8 +81,13 @@ function wplf_ajax_submit_handler() {
     $return->submission_title = $post_title;
     $return->form_id = $form->ID;
 
+    $success = get_post_meta( $form->ID, '_wplf_thank_you', true );
+    $success = apply_filters( "wplf_{$form->post_name}_success_message", $success );
+    $success = apply_filters( "wplf_{$form->ID}_success_message", $success );
+    $success = apply_filters( 'wplf_success_message', $success );
+
     // return the success message for the form
-    $return->success = apply_filters( 'the_content', get_post_meta( $form->ID, '_wplf_thank_you', true ) );
+    $return->success = $success;
 
     // allow user to attach custom actions after the submission has been received
     // these could be confirmation emails, additional processing for the submission fields, e.g.

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -100,6 +100,13 @@
     -->
     <exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
 
+    <!-- <?php doesn't have to be on its own line -->
+    <exclude name="Squiz.PHP.EmbeddedPhp.ContentBeforeEnd" />
+    <exclude name="Squiz.PHP.EmbeddedPhp.ContentAfterOpen" />
+
+    <!-- Squiz.PHP.EmbeddedPhp.ContentBeforeEnd -->
+    <exclude name="Generic.ControlStructures.InlineControlStructure.NotAllowed" />
+
     <!-- These indentation rules are just wrong :) -->
     <exclude name="PEAR.Functions.FunctionCallSignature.Indent" />
 
@@ -117,6 +124,9 @@
 
     <!-- This would be nice to enforce, but plugin main file shouldn't be called class-something -->
     <exclude name="WordPress.Files.FileName.InvalidClassFileName" />
+
+    <!-- This one is just weird. -->
+    <exclude name="WordPress.Arrays.ArrayIndentation" />
 
   </rule>
 </ruleset>

--- a/wp-libre-form.php
+++ b/wp-libre-form.php
@@ -88,7 +88,7 @@ class WP_Libre_Form {
    * Enable Polylang support
    */
   public function init_polylang_support() {
-    if ( apply_filters( 'wplf_load_polylang', true ) ) {
+    if ( apply_filters( 'wplf_load_polylang', true ) && class_exists( 'Polylang ' ) ) {
       require_once 'classes/class-wplf-polylang.php';
       WPLF_Polylang::init();
     }


### PR DESCRIPTION
Originally shipped without because it was supposed to be hard.
It wasn't.