### PR TITLE
Wrap in exists check

### DIFF
--- a/classes/class-wplf-polylang.php
+++ b/classes/class-wplf-polylang.php
@@ -85,9 +85,13 @@ if ( ! class_exists( 'WPLF_Polylang' ) ) {
 
       return $message;
     }
-
+    
     public function ajax_object( $array ) {
-      $array['lang'] = pll_current_language();
+      if ( function_exists( 'pll_current_language' ) ) {
+        $array['lang'] = pll_current_language();
+      } else {
+        $array['lang'] = null;
+      }
       return $array;
     }
 

--- a/classes/class-wplf-polylang.php
+++ b/classes/class-wplf-polylang.php
@@ -85,7 +85,7 @@ if ( ! class_exists( 'WPLF_Polylang' ) ) {
 
       return $message;
     }
-    
+
     public function ajax_object( $array ) {
       if ( function_exists( 'pll_current_language' ) ) {
         $array['lang'] = pll_current_language();


### PR DESCRIPTION
This class isn't initialized if Polylang doesn't exist, but Polylang doesn't define pll_current_language if there aren't any languages, eg. you have a fresh installation and haven't configured it yet.

Contents of ajax_object when no languages exist: 
`{ajax_url: "https://testitunkki.local/wp-admin/admin-ajax.php", ajax_credentials: "same-origin", lang: null}`

Contents of ajax_object when at least one language exists: 
`{ajax_url: "https://testitunkki.local/wp-admin/admin-ajax.php", ajax_credentials: "same-origin", lang: "en"}`