### PR TITLE
Attachment link fix

### DIFF
--- a/classes/class-cpt-wplf-submission.php
+++ b/classes/class-cpt-wplf-submission.php
@@ -278,7 +278,7 @@ class CPT_WPLF_Submission {
         }
         if ( $value_is_url ) {
           $link_text = __( 'Open Link', 'wp-libre-form' );
-          $possible_link = '<a target="_blank" href="' . $value . '" style="float:right">' . $link_text . '</a>';
+          $possible_link = '<a target="_blank" href="' . str_replace( $home_path, '/', $value ) . '" style="float:right">' . $link_text . '</a>';
         }
         ?>
         <tr>


### PR DESCRIPTION
$value contains the whole path as seen in the textarea. "Open link" href looked like /home/customer/public/wp-content/uploads/filename.jpg. Defined variable $home_path was not used anywhere. It contains the /home/customer/public/ part. We replace that with a slash in links and now links to uploaded files seem to work fine.