### PR TITLE
Add Permission Callback in order ton be compatible with WP latest version

### DIFF
--- a/wp-libre-form.php
+++ b/wp-libre-form.php
@@ -96,6 +96,7 @@ class WP_Libre_Form {
   public function register_rest_routes() {
     register_rest_route( 'wplf/v1', 'submit', [
       'methods' => 'POST',
+      'permission_callback' => '__return_true',
       'callback' => 'wplf_ajax_submit_handler', // admin-ajax handler, works but...
       // The REST API handbook discourages from using $_POST, and instead use $request->get_params()
     ]);


### PR DESCRIPTION
This is due to the recent change in WordPress Core: https://make.wordpress.org/core/2020/07/22/rest-api-changes-in-wordpress-5-5/

If permission_callback argument is not given, the following error will occur : 

Notice: register_rest_route was called incorrectly. The REST API route definition for wplf/v1/submit is missing the required permission_callback argument. For REST API routes that are intended to be public, use __return_true as the permission callback. Please see Debugging in WordPress for more information. (This message was added in version 5.5.0.)